### PR TITLE
cfn-lint --update-specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ LABEL "maintainer"="Scott Brenner <scott@scottbrenner.me>"
 
 RUN apk --no-cache add python3
 RUN pip3 install cfn-lint
+RUN cfn-lint --update-specs
 
 COPY cfn-lint.json /cfn-lint.json
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Using latest [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) versions

because sometimes the latest versions haven't made it into a `cfn-lint` release yet
