### PR TITLE
Update Docker base image to python:3.8-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM python:3.8-alpine
 
 LABEL name="cfn-lint-action"
 LABEL repository="https://github.com/ScottBrenner/cfn-lint-action"
@@ -11,8 +11,7 @@ LABEL "com.github.actions.color"="green"
 
 LABEL "maintainer"="Scott Brenner <scott@scottbrenner.me>"
 
-RUN apk --no-cache add python3
-RUN pip3 install cfn-lint
+RUN pip install cfn-lint --no-cache-dir
 RUN cfn-lint --update-specs
 RUN cfn-lint --update-iam-policies
 


### PR DESCRIPTION
This should make the startup time faster as it won't need to install python3 at build time.

This also follows the upstream docker image: https://github.com/aws-cloudformation/cfn-python-lint/blob/master/Dockerfile