### PR TITLE
feat(dev): GitHub Codespaces Configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.162.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 14, 12, 10
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends python3-venv
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,10 +6,3 @@ FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends python3-venv
-
-# [Optional] Uncomment if you want to install an additional version of node using nvm
-# ARG EXTRA_NODE_VERSION=10
-# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
-
-# [Optional] Uncomment if you want to install more global node packages
-# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.162.0/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		"args": { 
+			"VARIANT": "14"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,29 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.162.0/containers/typescript-node
 {
-	"name": "Node.js & TypeScript",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14
-		"args": { 
-			"VARIANT": "14"
-		}
-	},
+  "name": "Node.js & TypeScript",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 10, 12, 14
+    "args": {
+      "VARIANT": "14"
+    }
+  },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint"
-	],
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["dbaeumer.vscode-eslint"],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm install",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
 }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This should give you the same experience as before.
 This is a JavaScript GitHub Action that relies on Node for third party packages, and can be developed locally or in GitHub Codespaces.
 
 ### Running Locally
+
 To get this working on your local machine, firstly make sure you have a working [NodeJS](https://nodejs.org/en/) runtime. It is also recommended to use [Act](https://github.com/nektos/act) to test & run actions locally. These instructions assume you have the [GitHub CLI](https://cli.github.com/) installed.
 
 1. Firstly, [fork](https://cli.github.com/manual/gh_repo_fork) the repository by running:

--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ Below the above include the following:
 
 This should give you the same experience as before.
 
-## Running Locally
+## Development
 
-This is a JavaScript GitHub Action that relies on Node for third party packages. To get this working on your local machine, firstly make sure you have a working [NodeJS](https://nodejs.org/en/) runtime. It is also recommended to use [Act](https://github.com/nektos/act) to test & run actions locally. These instructions assume you have the [GitHub CLI](https://cli.github.com/) installed.
+This is a JavaScript GitHub Action that relies on Node for third party packages, and can be developed locally or in GitHub Codespaces.
+
+### Running Locally
+To get this working on your local machine, firstly make sure you have a working [NodeJS](https://nodejs.org/en/) runtime. It is also recommended to use [Act](https://github.com/nektos/act) to test & run actions locally. These instructions assume you have the [GitHub CLI](https://cli.github.com/) installed.
 
 1. Firstly, [fork](https://cli.github.com/manual/gh_repo_fork) the repository by running:
 
@@ -121,9 +124,13 @@ npm install
 node index.js
 ```
 
+### GitHub Codespaces
+
+If you’re in [the Codespaces beta](https://github.com/features/codespaces/signup), you’ll see a “Code” button in the Code tab of this repository. The default codespace configuration automatically installs and configures all dependencies necessary for development of this project.
+
 ## Contributing
 
-This product welcomes contributions from the open source community. Firstly, please raise an issue on the repository, as this will be used to discuss/agree on scope and feature/bug detail. Once agreed, please follow the [Running Locally](#running-locally) steps above to get started on your machine. Branch off `main` following logically branch naming conventions `feature/***` or `bug/***`. When contributing please try and meet these development principles:
+This product welcomes contributions from the open source community. Firstly, please raise an issue on the repository, as this will be used to discuss/agree on scope and feature/bug detail. Once agreed, please follow the [Development](#development) steps above to get started on your machine. Branch off `main` following logically branch naming conventions `feature/***` or `bug/***`. When contributing please try and meet these development principles:
 
 - This software product follows a module architecture, please try and stay consistent to making small, reusable `modules` of code within the `lib/utils` directory.
 - Ensure any new code updated the relevant unit tests found within the `tests/` directory. We use [Jest](https://jestjs.io/) for testing.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,27 +1,5 @@
-module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
-
-/***/ 932:
-/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
-
-const core = __nccwpck_require__(186);
-const path = __nccwpck_require__(622);
-
-const setup = __nccwpck_require__(391);
-
-(async () => {
-  try {
-    await setup();
-    const matchersPath = path.join(__dirname, "..", ".github");
-    core.info(`##[add-matcher]${path.join(matchersPath, "cfn-lint.json")}`);
-  } catch (error) {
-    core.setFailed(error.message);
-  }
-})();
-
-
-/***/ }),
 
 /***/ 391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
@@ -1874,8 +1852,9 @@ module.exports = require("util");;
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {
@@ -1900,10 +1879,27 @@ module.exports = require("util");;
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
-/******/ 	// module exports must be returned from runtime so entry inlining is disabled
-/******/ 	// startup
-/******/ 	// Load entry module and return exports
-/******/ 	return __nccwpck_require__(932);
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+const core = __nccwpck_require__(186);
+const path = __nccwpck_require__(622);
+
+const setup = __nccwpck_require__(391);
+
+(async () => {
+  try {
+    await setup();
+    const matchersPath = path.join(__dirname, "..", ".github");
+    core.info(`##[add-matcher]${path.join(matchersPath, "cfn-lint.json")}`);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+})();
+
+})();
+
+module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -24,3 +24,13 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@vercel/ncc
+MIT
+Copyright 2018 ZEIT, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "setup-cfn-lint",
-  "version": "0.1.0",
+  "name": "cfn-lint-action",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "setup-cfn-lint",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
+      "version": "2.1.0",
+      "license": "MIT License",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",


### PR DESCRIPTION
This Pull Request proposes a configuration for [GitHub Codespaces](https://docs.github.com/en/github/developing-online-with-codespaces/about-codespaces), files created by [Using a pre-built container configuration](https://docs.github.com/en/github/developing-online-with-codespaces/configuring-codespaces-for-your-project#using-a-pre-built-container-configuration), see [devcontainer.json reference](https://code.visualstudio.com/docs/remote/devcontainerjson-reference) for specifics.

[When Codespaces becomes generally available, you will be billed for storage and compute usage](https://docs.github.com/en/github/developing-online-with-codespaces/about-billing-for-codespaces), so I'll probably delete these configurations then .. but for now, this makes it easy to get up and running with developing for this Action - simply open the Codespace, it'll `npm install` automatically, and you're ready to go!:
```
node ➜ /workspaces/cfn-lint-action (feature/github-codespaces-config ✗) $ node index.js 
[command]/usr/bin/python3 --version
Python 3.7.3
[command]/usr/bin/python3 -m venv /tmp/setup-cfn-lint-a1hciw/.venv
...
Successfully installed attrs-20.3.0 aws-sam-translator-1.35.0 boto3-1.17.57 botocore-1.20.57 cfn-lint-0.48.3 decorator-4.4.2 importlib-metadata-4.0.1 jmespath-0.10.0 jsonpatch-1.32 jsonpointer-2.1 jsonschema-3.2.0 junit-xml-1.9 networkx-2.5.1 pyrsistent-0.17.3 python-dateutil-2.8.1 pyyaml-5.4.1 s3transfer-0.4.2 six-1.15.0 typing-extensions-3.7.4.3 urllib3-1.26.4 zipp-3.4.1
::add-path::/tmp/setup-cfn-lint-a1hciw/bin
##[add-matcher]/workspaces/.github/cfn-lint.json
```