### PR TITLE
fix: W2531 EOL runtime (nodejs10.x) specified

### DIFF
--- a/examples/template.yml
+++ b/examples/template.yml
@@ -60,8 +60,8 @@ Resources:
     Properties:
       FunctionName:
         Fn::Sub: lambda-function-${EnvName}
-      Description: LambdaFunctioni of nodejs10.x.
-      Runtime: nodejs10.x
+      Description: LambdaFunctioni of nodejs14.x.
+      Runtime: nodejs14.x
       Code:
         ZipFile:
           "exports.handler = function(event, context){\n

--- a/examples/template.yml
+++ b/examples/template.yml
@@ -60,8 +60,8 @@ Resources:
     Properties:
       FunctionName:
         Fn::Sub: lambda-function-${EnvName}
-      Description: LambdaFunctioni of nodejs14.x.
-      Runtime: nodejs14.x
+      Description: LambdaFunctioni of nodejs12.x.
+      Runtime: nodejs12.x
       Code:
         ZipFile:
           "exports.handler = function(event, context){\n


### PR DESCRIPTION
### Summary

Workflow runs in this repository are now failing due to
```
 W2531 EOL runtime (nodejs10.x) specified. Runtime is EOL since 2021-05-31 and updating will be disabled at 2021-06-30. Please consider updating to nodejs14.x
Error: ./examples/template.yml:64:7
```
(https://github.com/ScottBrenner/cfn-lint-action/pull/61/checks?check_run_id=2708313079#step:4:6)
As this file was copied from https://github.com/awslabs/aws-cloudformation-templates/blob/master/community/services/Lambda/LambdaSample.yaml#L62-L63, we can fix-forward here.

### Other Information

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
