### PR TITLE
fix(CI): Trigger CodeQL on everything except the "push" event for Dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches-ignore: dependabot/**
-  pull_request:
   schedule:
     - cron: '38 18 * * 3'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,12 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, v* ]
     branches-ignore: dependabot/**
   pull_request:
-    branches: [ main, v* ]
   schedule:
     - cron: '38 18 * * 3'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,7 @@ name: "CodeQL"
 on:
   push:
     branches: [ main, v* ]
+    branches-ignore: dependabot/**
   pull_request:
     branches: [ main, v* ]
   schedule:


### PR DESCRIPTION
### Summary
The CodeQL workflow fails on the "push" event for Dependabot branches - https://github.com/ScottBrenner/cfn-lint-action/actions/workflows/codeql-analysis.yml with an error message like:
```
Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
```
(https://github.com/ScottBrenner/cfn-lint-action/runs/2764966785?check_suite_focus=true#step:3:55)

So, this pull request proposes ignoring the "push" event for Dependabot branches.

Additionally removing specific branches for trigger events, don't we want this to run everywhere?

### Other Information
Reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
