### PR TITLE
feat(CI): Run "Tests" on all push events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,6 @@
 name: "Tests"
-on:
-  push:
-    branches:
-      - main
-      - feature/**
-      - bug/**
-  pull_request:
+on: [push]
+
 jobs:
   unit:
     name: npm test


### PR DESCRIPTION
### Summary
Proposing changing the "Tests" workflow to simply run on all `push` events

- Removing the `branches` restriction, might as well run everywhere
- Removing `pull_request` event as it would "duplicate" `push`, running twice
