### PR TITLE
feat(CI): Replace windows-2016 with windows-2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
         os:
           - ubuntu-18.04
           - ubuntu-20.04
-          - windows-2016
           - windows-2019
+          - windows-2022
           - macos-10.15
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Summary
https://github.com/actions/virtual-environments/issues/4312

> Windows Server 2016 Active support ends on 11 Jan 2022 and Windows Server 2022 VM image is going out of beta later this year

Semi-related to https://github.com/ScottBrenner/cfn-lint-action/issues/141, maybe