### PR TITLE
fix(docs): Use shopt for globbing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Change the action in your Workflow to be:
 ```
 - name: Print the Cloud Formation Linter Version & run Linter.
   run: |
-    setopt -s globstar # enable globbing
+    shopt -s globstar # enable globbing
     cfn-lint --version
     cfn-lint -t ./**/*.yaml
 ```


### PR DESCRIPTION
### Summary

By default, GitHub Actions uses a Bash shell and setopt is for ZSH shells, this updates the README with the correct command to use when globbing support is required.
