### PR TITLE
feat(problem-matchers): Add warnings to problem matchers

### DIFF
--- a/.github/cfn-lint.json
+++ b/.github/cfn-lint.json
@@ -4,9 +4,26 @@
             "owner": "cfn-lint",
             "pattern": [
                 {
-                    "regexp": "^([EWI](\\d{4}))\\s(.+)$",
-                    "code": 1,
-                    "message": 3
+                    "regexp": "^(([E](\\d{4}))\\s(.+))$",
+                    "message": 1,
+                    "code": 3
+                },
+                {
+                    "regexp": "^(\\S+):(\\d+):(\\d+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        },
+        {
+            "owner": "cfn-lint-warnings",
+            "severity": "warning",
+            "pattern": [
+                {
+                    "regexp": "^(([WI](\\d{4}))\\s(.+))$",
+                    "message": 1,
+                    "code": 3
                 },
                 {
                     "regexp": "^(\\S+):(\\d+):(\\d+)$",


### PR DESCRIPTION
### Summary

This PR enables warning annotations as an alternative to errors. If the severity is not specified in the problem matcher, it defaults to `error`. Only values accepted for severity  is `error` and `warning` case-insenitive, but unfortunately `cfn-lint` does not output any of those. It only produces a single letter for the type of the problem. Therefore, we can't directly use the matched group in the severity field. After some digging around, I've found that we can specify the severity field in the same level as owner. We can specify two owners, one for warnings and informational and one for errors.

I also took the liberty of including the error code in the message to make it more convenient to search the issue in [cfn-lint rules](https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/rules.md). I can revert it back if you'd like. With these changes the message displayed in the annotations will change from 

`Parameter EnvName is missing required property Type`
to
`E2001 Parameter EnvName is missing required property Type`
 
For some reason `code` field does not get displayed in the annotation message even if it gets matched properly. I have the same issue with `eslint` and could not find any open issues about that. 


### Other Information

I'm not a regex guru, there is probably much better way to do it but this is what I came up with: https://regex101.com/r/Qo5sGX/1 It creates an additional group from the whole text in addition to previous groups

Relevant docs:
https://github.com/actions/runner/blob/main/docs/adrs/0276-problem-matchers.md#supported-severity-levels
https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md#single-line-matchers

![cfn-lint](https://github.com/ScottBrenner/cfn-lint-action/assets/24387365/cd051b14-e5b1-4b68-83ed-d8df4b1a9248)

