### PR TITLE
Fix failing tests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -174,7 +174,7 @@ module.exports = {
     const cfnLint = isWindows() ? "cfn-lint.exe" : "cfn-lint";
     fs.symlinkSync(
       path.join(binPath, cfnLint),
-      path.join(symlinkPath, cfnLint)
+      path.join(symlinkPath, cfnLint),
     );
 
     return symlinkPath;
@@ -198,7 +198,7 @@ module.exports = {
       return response;
     } catch (e) {
       core.error(
-        `Error running command: ${command}. Returned error is: ${e.message}`
+        `Error running command: ${command}. Returned error is: ${e.message}`,
       );
       throw e;
     }

--- a/lib/utils/installCLI.js
+++ b/lib/utils/installCLI.js
@@ -46,7 +46,7 @@ module.exports = {
     const cfnLint = isWindows() ? "cfn-lint.exe" : "cfn-lint";
     fs.symlinkSync(
       path.join(binPath, cfnLint),
-      path.join(symlinkPath, cfnLint)
+      path.join(symlinkPath, cfnLint),
     );
 
     return symlinkPath;

--- a/lib/utils/runCommand.js
+++ b/lib/utils/runCommand.js
@@ -9,7 +9,7 @@ module.exports = {
       return response;
     } catch (e) {
       core.error(
-        `Error running command: ${command}. Returned error is: ${e.message}`
+        `Error running command: ${command}. Returned error is: ${e.message}`,
       );
       throw e;
     }

--- a/tests/runCommand.test.js
+++ b/tests/runCommand.test.js
@@ -22,7 +22,7 @@ describe("runCommand Test", () => {
   it("Successfully handles failure CFN-Lint Command", async () => {
     const command = { command: "cfn-lint -t ./template.yml" };
     const expectedReturnValue = new Error(
-      "You have Errors in your Cloud Formation"
+      "You have Errors in your Cloud Formation",
     );
 
     jest.spyOn(exec, "exec").mockImplementation(() => {
@@ -35,7 +35,7 @@ describe("runCommand Test", () => {
       await runCommand(command);
     } catch (e) {
       expect(e.message).toStrictEqual(
-        "You have Errors in your Cloud Formation"
+        "You have Errors in your Cloud Formation",
       );
       expect(log).toHaveBeenCalledTimes(1);
     }

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -58,7 +58,7 @@ test.each([
   expect(io.which).toHaveBeenCalledWith(test.expected.python, true);
   expect(exec.exec).toHaveBeenCalledWith(
     expect.anything(),
-    expect.arrayContaining(["install", `cfn-lint==${test.expected.version}`])
+    expect.arrayContaining(["install", `cfn-lint==${test.expected.version}`]),
   );
   expect(core.addPath).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
### Summary

Resolving https://github.com/ScottBrenner/cfn-lint-action/actions/runs/5579137792/jobs/10194286881#step:5:87.

### Other Information

```
$ npm run all

> cfn-lint-action@2.1.0 all /workspaces/cfn-lint-action
> npm run format && npm test && npm run build


> cfn-lint-action@2.1.0 format /workspaces/cfn-lint-action
> prettier --write .

.devcontainer/devcontainer.json 63ms
.eslintrc.json 3ms
action.yml 36ms
CHANGELOG.md 33ms
CODE_OF_CONDUCT.md 57ms
CONTRIBUTING.md 8ms
index.js 14ms
lib/setup.js 9ms
lib/utils/getInput.js 8ms
lib/utils/getInputs.js 8ms
lib/utils/helpers.js 16ms
lib/utils/installCLI.js 36ms
lib/utils/runCommand.js 6ms
package-lock.json 159ms
package.json 4ms
README.md 95ms
SECURITY.md 4ms
tests/getInput.test.js 14ms
tests/helpers.test.js 24ms
tests/runCommand.test.js 18ms
tests/setup.test.js 28ms

> cfn-lint-action@2.1.0 test /workspaces/cfn-lint-action
> jest --coverage --verbose && eslint . && prettier --check .

 PASS  tests/setup.test.js
  ✓ setup {
  platform: 'linux',
  input: {},
  expected: { version: '0.*', python: 'python3' }
} (6 ms)
  ✓ setup {
  platform: 'darwin',
  input: {},
  expected: { version: '0.*', python: 'python3' }
} (1 ms)
  ✓ setup {
  platform: 'win32',
  input: {},
  expected: { version: '0.*', python: 'python' }
} (1 ms)
  ✓ setup {
  platform: 'linux',
  input: { version: '0.44.4' },
  expected: { version: '0.44.4', python: 'python3' }
} (6 ms)
  ✓ setup {
  platform: 'linux',
  input: { python: 'python3' },
  expected: { version: '0.*', python: 'python3' }
} (1 ms)
  ✓ setup {
  platform: 'linux',
  input: { version: '0.44.4', python: 'python3' },
  expected: { version: '0.44.4', python: 'python3' }
} (1 ms)
  ✓ invalid input { version: 'not valid' } (21 ms)
  ✓ invalid input { version: 'not|valid' } (1 ms)

 PASS  tests/getInput.test.js
  getInput Test
    ✓ Returns Valid Value
    ✓ Handles Unsuccessul Value
    ✓ Handles Default Value

 PASS  tests/helpers.test.js
  helpers Test
    ✓ Returns Valid OS for Linux (1 ms)
    ✓ Returns Valid OS for MacOS
    ✓ Returns Valid OS for Windows (1 ms)
    ✓ Temporary Directory Contains String(s) (1 ms)
    ✓ Ensures Exec & IO which get called (1 ms)

Ran command: cfn-lint -t ./template.yml. Response is: 
::error::Error running command: cfn-lint -t ./template.yml. Returned error is: You have Errors in your Cloud Formation
 PASS  tests/runCommand.test.js
  runCommand Test
    ✓ Successfully handles passed CFN-Lint Command (2 ms)
    ✓ Successfully handles failure CFN-Lint Command (1 ms)

----------------|---------|----------|---------|---------|-------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------|---------|----------|---------|---------|-------------------
All files       |   94.87 |      100 |     100 |   94.87 |                   
 lib            |   80.95 |      100 |     100 |   80.95 |                   
  setup.js      |   80.95 |      100 |     100 |   80.95 | 21-22,34-35       
 lib/utils      |     100 |      100 |     100 |     100 |                   
  getInput.js   |     100 |      100 |     100 |     100 |                   
  getInputs.js  |     100 |      100 |     100 |     100 |                   
  helpers.js    |     100 |      100 |     100 |     100 |                   
  installCLI.js |     100 |      100 |     100 |     100 |                   
  runCommand.js |     100 |      100 |     100 |     100 |                   
----------------|---------|----------|---------|---------|-------------------
Test Suites: 4 passed, 4 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        1.71 s
Ran all test suites.
Checking formatting...
All matched files use Prettier code style!

> cfn-lint-action@2.1.0 build /workspaces/cfn-lint-action
> ncc build index.js --out dist --license licenses.txt

ncc: Version 0.36.1
ncc: Compiling file index.js into CJS
  6kB  dist/licenses.txt
148kB  dist/index.js
154kB  [1471ms] - ncc 0.36.1
```