### PR TITLE
FIX: Husky v10 prep

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged
 npm run all

--- a/dist/index.js
+++ b/dist/index.js
@@ -81,7 +81,7 @@ module.exports = {
     const defaultPython = isWindows() ? "python" : "python3";
 
     try {
-      const version = getInput("version", /^[\d.*]+$/, "1.*");
+      const version = getInput("version", /^[\d.*]+$/, "0.*");
       const command = getInput("command", /^cfn-lint\s || null/, null);
       const python = getInput("python", /^.+$/, defaultPython);
       return { version, command, python };

--- a/dist/index.js
+++ b/dist/index.js
@@ -81,7 +81,7 @@ module.exports = {
     const defaultPython = isWindows() ? "python" : "python3";
 
     try {
-      const version = getInput("version", /^[\d.*]+$/, "0.*");
+      const version = getInput("version", /^[\d.*]+$/, "1.*");
       const command = getInput("command", /^cfn-lint\s || null/, null);
       const python = getInput("python", /^.+$/, defaultPython);
       return { version, command, python };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "ncc build index.js --out dist --license licenses.txt",
     "format": "prettier --write .",
     "all": "npm run format && npm test && npm run build",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "license": "MIT License",
   "dependencies": {


### PR DESCRIPTION
### Summary

Implements migrations from https://github.com/typicode/husky/releases/tag/v9.0.1 to for v10 compatibility described in https://github.com/typicode/husky/releases/tag/v9.1.2