### PR TITLE
Rework install logic

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.162.0/containers/typescript-node/.devcontainer/base.Dockerfile
 
-# [Choice] Node.js version: 14, 12, 10
-ARG VARIANT="14-buster"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+# [Choice] Node.js version
+ARG VARIANT="24"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends python3-venv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,9 @@
   "name": "Node.js & TypeScript",
   "build": {
     "dockerfile": "Dockerfile",
-    // Update 'VARIANT' to pick a Node version: 10, 12, 14
+    // Update 'VARIANT' to pick a Node version
     "args": {
-      "VARIANT": "20"
+      "VARIANT": "24"
     }
   },
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Cloud Formation Linter with Latest Version
-        uses: scottbrenner/cfn-lint-action@v2
+        uses: scottbrenner/cfn-lint-action@v2.7.0
 
       - name: Print the Cloud Formation Linter Version & run Linter.
         run: |
@@ -56,20 +56,20 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Testing with CFN Lint Command
-        uses: scottbrenner/cfn-lint-action@v2
+        uses: scottbrenner/cfn-lint-action@v2.7.0
         with:
           command: cfn-lint -t ./template.yml
 ```
 
 Further, you can configure this action to download a specific version of the [CloudFormation Linter](https://github.com/aws-cloudformation/cfn-python-lint/), as well as the Python interpreter. See the table below for all the `INPUTS` this action can take.
 
-| Input Name | Input Description                                   | Default Value                                                         | Required? |
-| ---------- | --------------------------------------------------- | --------------------------------------------------------------------- | --------- |
-| version    | Version of CFN PyPi Package                         | Latest Version of CFN PyPi Package with all the optional dependencies | false     |
-| python     | Python Version                                      | Defaults to `python` on Windows, and `python3` otherwise.             | false     |
-| command    | Cloud Formation Linter Command to Run After Install | N/A                                                                   | false     |
+| Input Name | Input Description                                                                  | Default Value                                                         | Required? |
+| ---------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------- | --------- |
+| version    | Version of CFN PyPi Package; supports optional dependencies and version specifiers | Latest Version of CFN PyPi Package with all the optional dependencies | false     |
+| python     | Python Version                                                                     | Defaults to `python` on Windows, and `python3` otherwise.             | false     |
+| command    | Cloud Formation Linter Command to Run After Install                                | N/A                                                                   | false     |
 
-From v2.4.8 onwards, [optional dependencies](https://github.com/aws-cloudformation/cfn-lint?tab=readme-ov-file#optional-dependencies) and [version specifier](https://peps.python.org/pep-0440/#version-specifiers) can be input as below. If a version is provided as input it must include a specifier as well e.g. `"==1.24.0"`.
+From v2.4.8 onwards, [optional dependencies](https://github.com/aws-cloudformation/cfn-lint?tab=readme-ov-file#optional-dependencies) and [version specifier](https://peps.python.org/pep-0440/#version-specifiers) can be input as below. You can also specify a bare version such as `1.24.0`.
 
 ```yaml
 name: Lint CloudFormation Templates
@@ -82,12 +82,34 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Testing with CFN Lint Command
-        uses: scottbrenner/cfn-lint-action@v2
+        uses: scottbrenner/cfn-lint-action@v2.7.0
         with:
           version: "[sarif]>=1.0"
+          command: cfn-lint -t ./template.yml
+```
+
+You can also specify a plain version without extras or specifiers:
+
+```yaml
+name: Lint CloudFormation Templates
+
+on: [push]
+
+jobs:
+  cloudformation-linter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Testing with CFN Lint Command
+        uses: scottbrenner/cfn-lint-action@v2.7.0
+        with:
+          version: "1.24.0"
           command: cfn-lint -t ./template.yml
 ```
 
@@ -107,7 +129,7 @@ Change the action in your Workflow to be:
 
 ```
 - name: Setup Cloud Formation Linter with Latest Version
-  uses: scottbrenner/cfn-lint-action@v2
+  uses: scottbrenner/cfn-lint-action@v2.7.0
 ```
 
 #### Step Two

--- a/dist/index.js
+++ b/dist/index.js
@@ -81,7 +81,11 @@ module.exports = {
     const defaultPython = isWindows() ? "python" : "python3";
 
     try {
-      const version = getInput("version", /[a-zA-Z0-9]+/, "[full]==1.*");
+      const version = getInput(
+        "version",
+        /^(?:[A-Za-z0-9.*]+|(?:\[[A-Za-z0-9_,]+\])?\s*(?:==|!=|<=|>=|~=|===|<|>)\s*[A-Za-z0-9.*]+)$/,
+        "[full]==1.*",
+      );
       const command = getInput("command", /^cfn-lint\s || null/, null);
       const python = getInput("python", /^.+$/, defaultPython);
       return { version, command, python };
@@ -159,13 +163,18 @@ module.exports = {
       "setuptools",
       "wheel",
     ]);
+    const normalizedVersion = version.replace(/\s+/g, "");
+    const installTarget = /^[A-Za-z0-9.*]+$/.test(normalizedVersion)
+      ? `cfn-lint[full]==${normalizedVersion}`
+      : `cfn-lint${normalizedVersion}`;
+
     // Install latest compatible version
     await exec.exec(pythonPath, [
       "-m",
       "pip",
       "install",
       "--upgrade",
-      `cfn-lint${version}`,
+      installTarget,
     ]);
 
     // Symlink from separate directory so only CFN LINT CLI is added to PATH

--- a/lib/utils/getInputs.js
+++ b/lib/utils/getInputs.js
@@ -9,7 +9,11 @@ module.exports = {
     const defaultPython = isWindows() ? "python" : "python3";
 
     try {
-      const version = getInput("version", /[a-zA-Z0-9]+/, "[full]==1.*");
+      const version = getInput(
+        "version",
+        /^(?:[A-Za-z0-9.*]+|(?:\[[A-Za-z0-9_,]+\])?\s*(?:==|!=|<=|>=|~=|===|<|>)\s*[A-Za-z0-9.*]+)$/,
+        "[full]==1.*",
+      );
       const command = getInput("command", /^cfn-lint\s || null/, null);
       const python = getInput("python", /^.+$/, defaultPython);
       return { version, command, python };

--- a/lib/utils/installCLI.js
+++ b/lib/utils/installCLI.js
@@ -31,13 +31,18 @@ module.exports = {
       "setuptools",
       "wheel",
     ]);
+    const normalizedVersion = version.replace(/\s+/g, "");
+    const installTarget = /^[A-Za-z0-9.*]+$/.test(normalizedVersion)
+      ? `cfn-lint[full]==${normalizedVersion}`
+      : `cfn-lint${normalizedVersion}`;
+
     // Install latest compatible version
     await exec.exec(pythonPath, [
       "-m",
       "pip",
       "install",
       "--upgrade",
-      `cfn-lint${version}`,
+      installTarget,
     ]);
 
     // Symlink from separate directory so only CFN LINT CLI is added to PATH

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -18,32 +18,65 @@ test.each([
   {
     platform: "linux",
     input: {},
-    expected: { version: "[full]==1.*", python: "python3" },
+    expected: {
+      version: "[full]==1.*",
+      python: "python3",
+      install: "cfn-lint[full]==1.*",
+    },
   },
   {
     platform: "darwin",
     input: {},
-    expected: { version: "[full]==1.*", python: "python3" },
+    expected: {
+      version: "[full]==1.*",
+      python: "python3",
+      install: "cfn-lint[full]==1.*",
+    },
   },
   {
     platform: "win32",
     input: {},
-    expected: { version: "[full]==1.*", python: "python" },
+    expected: {
+      version: "[full]==1.*",
+      python: "python",
+      install: "cfn-lint[full]==1.*",
+    },
   },
   {
     platform: "linux",
     input: { version: "[full]>=0.44.4" },
-    expected: { version: "[full]>=0.44.4", python: "python3" },
+    expected: {
+      version: "[full]>=0.44.4",
+      python: "python3",
+      install: "cfn-lint[full]>=0.44.4",
+    },
   },
   {
     platform: "linux",
     input: { python: "python3" },
-    expected: { version: "[full]==1.*", python: "python3" },
+    expected: {
+      version: "[full]==1.*",
+      python: "python3",
+      install: "cfn-lint[full]==1.*",
+    },
   },
   {
     platform: "linux",
     input: { version: "[full]~=0.44.4", python: "python3" },
-    expected: { version: "[full]~=0.44.4", python: "python3" },
+    expected: {
+      version: "[full]~=0.44.4",
+      python: "python3",
+      install: "cfn-lint[full]~=0.44.4",
+    },
+  },
+  {
+    platform: "linux",
+    input: { version: "1.2.3", python: "python3" },
+    expected: {
+      version: "1.2.3",
+      python: "python3",
+      install: "cfn-lint[full]==1.2.3",
+    },
   },
 ])("setup %o", async (test) => {
   jest.spyOn(os, "platform").mockReturnValue(test.platform);
@@ -58,7 +91,7 @@ test.each([
   expect(io.which).toHaveBeenCalledWith(test.expected.python, true);
   expect(exec.exec).toHaveBeenCalledWith(
     expect.anything(),
-    expect.arrayContaining(["install", `cfn-lint${test.expected.version}`]),
+    expect.arrayContaining(["install", test.expected.install]),
   );
   expect(core.addPath).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
### Summary

Reworks breaking changes to install logic from https://github.com/ScottBrenner/cfn-lint-action/commit/0696545a68edbeb39abe4090b230845d7b715e8e

- Updated installCLI.js
  - Normalizes version input whitespace
  - Uses `cfn-lint[full]==<version>` for bare version values
  - Uses `cfn-lint<version>` when the input already includes a specifier or extras

- Updated getInputs.js
  - Expanded version validation to accept plain version strings as well as specifier/extras forms

- Updated bundled entrypoint index.js
  - Kept distributed code in sync with the source fix

- Updated setup.test.js
  - Added coverage for plain version input (`1.2.3`)
  - Corrected install target expectations

### Other Information
Also updates Codespaces to Node 24.

Closes https://github.com/ScottBrenner/cfn-lint-action/issues/626
